### PR TITLE
MathComp 1.12.0 is supported

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.11.0-coq-8.12'
           - 'mathcomp/mathcomp:1.11.0-coq-8.11'
           - 'mathcomp/mathcomp:1.11.0-coq-8.10'

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and number theory.
 - License: [MIT License](LICENSE)
 - Compatible Coq versions: 8.10 or later
 - Additional dependencies:
-  - [MathComp ssreflect 1.11.0 or later](https://math-comp.github.io)
+  - [MathComp ssreflect 1.11 or later](https://math-comp.github.io)
   - [MathComp algebra](https://math-comp.github.io)
 - Coq namespace: `gaia`
 - Related publication(s):
@@ -46,13 +46,25 @@ and number theory.
   - [Fibonacci numbers and the Stern-Brocot tree in Coq](https://hal.inria.fr/hal-01093589) 
   - [Implementation of three types of ordinals in Coq](https://hal.inria.fr/hal-00911710) 
 
-## Building instructions
+## Building and installation instructions
+
+The easiest way to install the latest released version of Gaia
+is via [OPAM](https://opam.ocaml.org/doc/Install.html):
+
+```shell
+opam repo add coq-released https://coq.inria.fr/opam/released
+opam install coq-gaia
+```
+
+To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/coq-community/gaia
+git clone https://github.com/coq-community/gaia.git
 cd gaia
-make   # or make -j <number-of-cores-on-your-machine>
+make   # or make -j <number-of-cores-on-your-machine> 
+make install
 ```
+
 
 ## Documentation
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,6 +2,8 @@
 -arg -w -arg -notation-overridden
 -arg -w -arg -notation-incompatible-format
 -arg -w -arg -ambiguous-paths
+-arg -w -arg -deprecated-hint-without-locality
+-arg -w -arg -deprecated-ident-entry
 theories/fibm.v
 theories/sset1.v
 theories/sset10.v

--- a/coq-gaia.opam
+++ b/coq-gaia.opam
@@ -17,7 +17,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.11.0" & < "1.12~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.11" & < "1.13~") | (= "dev")}
   "coq-mathcomp-algebra" 
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -55,9 +55,9 @@ supported_coq_versions:
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.11.0" & < "1.12~") | (= "dev")}'
+    version: '{(>= "1.11" & < "1.13~") | (= "dev")}'
   description: |-
-    [MathComp ssreflect 1.11.0 or later](https://math-comp.github.io)
+    [MathComp ssreflect 1.11 or later](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-algebra
   description: |-
@@ -66,6 +66,8 @@ dependencies:
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
+- version: '1.12.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
 - version: '1.11.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
 - version: '1.11.0-coq-8.11'
@@ -81,15 +83,6 @@ keywords:
 
 categories:
 - name: Mathematics/Logic/Set theory
-
-build: |-
-  ## Building instructions
-  
-  ``` shell
-  git clone https://github.com/coq-community/gaia
-  cd gaia
-  make   # or make -j <number-of-cores-on-your-machine>
-  ```
 
 documentation: |-
   ## Documentation

--- a/theories/dune
+++ b/theories/dune
@@ -2,4 +2,4 @@
  (name gaia)
  (package coq-gaia)
  (synopsis "Implementation of books from Bourbaki's Elements of Mathematics in Coq")
- (flags -w -notation-overridden -w -notation-incompatible-format -w -ambiguous-paths))
+ (flags -w -notation-overridden -w -notation-incompatible-format -w -ambiguous-paths -w -deprecated-hint-without-locality -w -deprecated-ident-entry))


### PR DESCRIPTION
Test 1.12.0 in CI, update opam files. Also ignore some warnings that will appear in Coq 8.13.