### PR TITLE
add backwards-compatible explicit hint locality to avoid warning in 8.13

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -2,7 +2,6 @@
 -arg -w -arg -notation-overridden
 -arg -w -arg -notation-incompatible-format
 -arg -w -arg -ambiguous-paths
--arg -w -arg -deprecated-hint-without-locality
 -arg -w -arg -deprecated-ident-entry
 theories/fibm.v
 theories/sset1.v

--- a/coq-gaia.opam
+++ b/coq-gaia.opam
@@ -16,7 +16,7 @@ and number theory."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.11" & < "1.13~") | (= "dev")}
   "coq-mathcomp-algebra" 
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -50,7 +50,7 @@ license:
 
 supported_coq_versions:
   text: '8.10 or later'
-  opam: '{(>= "8.10" & < "8.13~") | (= "dev")}'
+  opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
 
 dependencies:
 - opam:

--- a/theories/dune
+++ b/theories/dune
@@ -2,4 +2,4 @@
  (name gaia)
  (package coq-gaia)
  (synopsis "Implementation of books from Bourbaki's Elements of Mathematics in Coq")
- (flags -w -notation-overridden -w -notation-incompatible-format -w -ambiguous-paths -w -deprecated-hint-without-locality -w -deprecated-ident-entry))
+ (flags -w -notation-overridden -w -notation-incompatible-format -w -ambiguous-paths -w -deprecated-ident-entry))

--- a/theories/sset1.v
+++ b/theories/sset1.v
@@ -231,7 +231,7 @@ Qed.
 Lemma sub0_set x : sub emptyset x.
 Proof. by move=> t /in_set0. Qed.
 
-Hint Resolve sub0_set sub_refl : fprops.
+Global Hint Resolve sub0_set sub_refl : fprops.
 
 Lemma sub_set0 x: sub x emptyset <-> (x = emptyset).
 Proof.  
@@ -340,7 +340,7 @@ Proof. by apply /IM_P; exists false. Qed.
 Lemma set2_hi z x y: inc z (doubleton x y) -> z = x \/ z = y.
 Proof. by move/IM_P => [][]; [left | right]. Qed.
 
-Hint Resolve set2_1 set2_2: fprops.
+Global Hint Resolve set2_1 set2_2: fprops.
 
 Lemma set2_P z x y : inc z (doubleton x y) <-> (z = x \/ z = y).
 Proof. split; [apply: set2_hi | by case => ->; fprops]. Qed.
@@ -391,7 +391,7 @@ Proof. by case/set2_P. Qed.
 Lemma set1_1 x: inc x (singleton x).
 Proof. by apply/set2_P;left. Qed.
 
-Hint Resolve set1_1: fprops.
+Global Hint Resolve set1_1: fprops.
 
 Lemma set1_P y x: inc y (singleton x) <-> (y = x).
 Proof. by split; [ apply:set1_eq| move => ->; fprops ]. Qed.
@@ -405,7 +405,7 @@ Proof. by apply: set2_ne. Qed.
 Lemma set1_sub x X: inc x X -> sub (singleton x) X.
 Proof. by move=> ixy; apply: sub_set2. Qed.
 
-Hint Resolve set1_ne: fprops.
+Global Hint Resolve set1_ne: fprops.
 
 Definition C0 := emptyset.
 Definition C1 := singleton C0.
@@ -429,8 +429,8 @@ Proof. exact: set2_1. Qed.
 Lemma inc_C1_C2: inc C1 C2.
 Proof. exact: set2_2. Qed.
 
-Hint Resolve C0_ne_C1 C1_ne_C0: fprops.
-Hint Resolve inc_C0_C2 inc_C1_C2: fprops.
+Global Hint Resolve C0_ne_C1 C1_ne_C0: fprops.
+Global Hint Resolve inc_C0_C2 inc_C1_C2: fprops.
 
 
 Definition alls (X: Set)(P: property) := forall a, inc a X -> P a.
@@ -519,7 +519,7 @@ Proof. exact: Zo_P. Qed.
 Lemma setC_i x A B: inc x A -> ~ inc x B -> inc x (A -s B).
 Proof. by move => xa xb; apply /setC_P. Qed.
 
-Hint Resolve  setC_i: fprops.
+Global Hint Resolve  setC_i: fprops.
 
 Lemma nin_setC x A B: inc x A -> ~ inc x (A -s B) -> inc x B.
 Proof. move=> xa nx_cab; ex_middle h; case: nx_cab; fprops. Qed.
@@ -687,7 +687,7 @@ Proof. move => xa; apply (setU_i xa); fprops. Qed.
 Lemma setU2_2 x A B: inc x B -> inc x (A \cup B).
 Proof. move => xb;apply: (setU_i xb); fprops. Qed.
 
-Hint Resolve setU2_1 setU2_2: fprops.
+Global Hint Resolve setU2_1 setU2_2: fprops.
 
 Lemma setU2_P x A B: inc x (A \cup B) <-> (inc x A \/ inc x B).
 Proof. by split; [apply: setU2_hi | case; fprops ]. Qed. 
@@ -827,7 +827,7 @@ Proof. by move=> x xA; apply/setU1_P; left. Qed.
 Lemma setU1_r A b x: inc x A -> inc x (A +s1 b).
 Proof. apply: sub_setU1. Qed.
 
-Hint Resolve setU1_1 setU1_r sub_setU1: fprops.
+Global Hint Resolve setU1_1 setU1_r sub_setU1: fprops.
 
 Lemma setU1_eq A b: inc b A -> A +s1 b = A.
 Proof. 
@@ -1142,7 +1142,7 @@ move => xa xb.
 by apply: setI_i; [ apply: set2_ne | move=> t /set2_P [] -> ].
 Qed.
 
-Hint Resolve setI2_i : fprops.
+Global Hint Resolve setI2_i : fprops.
 
 Lemma setI2_1 A B: sub (A \cap B) A.
 Proof. move => x xi; apply: (setI_hi xi); fprops. Qed.
@@ -1590,7 +1590,7 @@ Definition pairp (x : Set) := (J (P x) (Q x) = x).
 Lemma pair_is_pair x y: pairp (J x y). 
 Proof. by rewrite /pairp; aw. Qed.
 
-Hint Resolve pair_is_pair: fprops.
+Global Hint Resolve pair_is_pair: fprops.
 
 Lemma pair_exten x y:
   pairp x -> pairp y -> P x = P y -> Q x = Q y -> x = y.
@@ -1641,7 +1641,7 @@ Proof.
 by split; [move/setX_P=> [_]; aw | move=> [xa ya]; apply: setXp_i].
 Qed.
 
-Hint Resolve setXp_i: fprops.
+Global Hint Resolve setXp_i: fprops.
 
 
 (** A product is empty if and only one factor is empty *)
@@ -1878,7 +1878,7 @@ move=> [_ fg] ia ib.
 move: (fg _ _ ia ib); aw => h; exact: (pr2_def (h (erefl x))).
 Qed. 
 
-Hint Resolve fgraph_sg : fprops.
+Global Hint Resolve fgraph_sg : fprops.
 
 (** We give here some properties of the domain and range *)
 
@@ -1889,7 +1889,7 @@ Proof. by apply: funI_i. Qed.
 Lemma range_i2 f x: inc x f -> inc (Q x) (range f). 
 Proof. by apply: funI_i. Qed.
 
-Hint Resolve domain_i1 range_i2: fprops.
+Global Hint Resolve domain_i1 range_i2: fprops.
 
 Lemma domain_i f x y: inc (J x y) f -> inc x (domain f). 
 Proof. by move/domain_i1; aw. Qed.
@@ -2017,7 +2017,7 @@ Proof. by rewrite domain_setU2 domain_set1. Qed.
 Lemma sgraph_set0: sgraph emptyset.
 Proof. by move=> t [][]. Qed. 
 
-Hint Resolve sgraph_set0 : fprops.
+Global Hint Resolve sgraph_set0 : fprops.
 Hint Rewrite range_set0 domain_set0 : aw.
 
 Lemma fgraph_set0: fgraph emptyset.
@@ -2107,7 +2107,7 @@ Lemma inc_V_range x: inc x (domain f) -> inc (Vg f x) (range f).
 Proof. move=> xd; apply/range_gP; ex_tac. Qed.
 
 End Vprops.
-Hint Resolve inc_V_range: fprops.
+Global Hint Resolve inc_V_range: fprops.
 
 
 Lemma simple_fct a b A B (f := singleton (J a b)):
@@ -2167,7 +2167,7 @@ by rewrite Lgd.
 Qed.
 
 Hint Rewrite Lgd Lgcomp_domain : aw. 
-Hint Resolve Lg_fgraph: fprops.
+Global Hint Resolve Lg_fgraph: fprops.
 
 Lemma LgV x p y: inc y x -> Vg (Lg x p) y = p y. 
 Proof. 
@@ -2238,7 +2238,7 @@ Qed.
 Lemma identity_ev x a: inc x a -> Vg (identity_g a) x = x.
 Proof. by rewrite/identity_g => /(LgV (p := id)). Qed.
 
-Hint Resolve identity_sgraph : fprops.
+Global Hint Resolve identity_sgraph : fprops.
 Hint Rewrite  identity_ev : bw.
 
 Definition cst_graph x y:= Lg x (fun _ => y).
@@ -2260,7 +2260,7 @@ Lemma cst_graph_fgraph a b: fgraph (cst_graph a b).
 Proof. rewrite /cst_graph; fprops. Qed.
 
 Hint Rewrite cst_graph_d : aw.
-Hint Resolve cst_graph_fgraph: fprops.
+Global Hint Resolve cst_graph_fgraph: fprops.
 
 Lemma setU1_V_out f x y:
   fgraph f -> ~ (inc x (domain f)) ->  Vg (f +s1 (J x y)) x = y.
@@ -2318,7 +2318,7 @@ Proof. by move=>  ix; rewrite LgV.  Qed.
 
 Hint Rewrite restr_d: aw.
 Hint Rewrite restr_ev: bw.
-Hint Resolve restr_fgraph : fprops.
+Global Hint Resolve restr_fgraph : fprops.
 
 Lemma double_restr f a b: sub a b -> (restr (restr f b) a) = (restr f a).
 Proof.  
@@ -2382,7 +2382,7 @@ apply: pc; apply /(range_gP pb); ex_tac.
 Qed.
 
 
-Hint Resolve composef_fgraph: fprops.
+Global Hint Resolve composef_fgraph: fprops.
 
 
 End Function.

--- a/theories/sset11.v
+++ b/theories/sset11.v
@@ -139,7 +139,7 @@ move: cdo_wor => [pa pb] wor wor'; apply: orsum_wor; first by aw.
 by hnf;aw;move=> i ind; try_lvariant ind.
 Qed.
 
-Hint Resolve  orsum2_wor orprod2_wor: fprops.
+Global Hint Resolve  orsum2_wor orprod2_wor: fprops.
 
 Lemma set_ord_lt_prop3a a: ordinalp a -> ole_on a = ordinal_o a.
 Proof.
@@ -287,7 +287,7 @@ Proof.
 move=> wo1 wo2; apply: OS_ordinal; fprops.
 Qed.
 
-Hint Resolve OS_sum2 OS_prod2 : fprops.
+Global Hint Resolve OS_sum2 OS_prod2 : fprops.
 
 Lemma orsum_invariant1 r r' f g g':
   order_on r (domain g) -> 

--- a/theories/sset12.v
+++ b/theories/sset12.v
@@ -3446,7 +3446,7 @@ case: (ord2_trichotomy ox).
   apply:(ord_induction_p5 (erefl opow') ax1 xo oy).
 Qed.
 
-Hint Resolve OS_pow : fprops.
+Global Hint Resolve OS_pow : fprops.
 
 Lemma opow_normal x: \2o <=o x ->
   normal_ofs (opow x).

--- a/theories/sset14.v
+++ b/theories/sset14.v
@@ -2103,7 +2103,7 @@ Qed.
 Lemma CS_aleph x: ordinalp x -> cardinalp (\aleph x).
 Proof. by move=> /CIS_aleph []. Qed.
 
-Hint Resolve CS_aleph: fprops.
+Global Hint Resolve CS_aleph: fprops.
 
 Lemma OS_aleph x: ordinalp x -> ordinalp (\omega x).
 Proof. by move=> /CS_aleph []. Qed.

--- a/theories/sset2.v
+++ b/theories/sset2.v
@@ -46,7 +46,7 @@ Proof. by move=> t /setX_P []. Qed.
 Lemma sub_setX_graph u x y: sub u (x \times y) -> sgraph u.
 Proof. move=> su t tu; exact: (setX_graph (su _ tu)). Qed. 
 
-Hint Resolve setX_graph: fprops.
+Global Hint Resolve setX_graph: fprops.
 
 Lemma setX_relP x y a b:
   related (x \times y) a b <-> (inc a x /\ inc b y).
@@ -165,7 +165,7 @@ Lemma corresp_sub_domain g:
   correspondence g -> sub (domain (graph g)) (source g).
 Proof. by move /corr_propc => [_].  Qed.
 
-Hint Resolve corresp_sub_range corresp_sub_domain corresp_is_graph: fprops.
+Global Hint Resolve corresp_sub_range corresp_sub_domain corresp_is_graph: fprops.
 
 (** The set of correspondences  [E->F] is the product of [P] and [singleton E] 
    and [singleton F], where [P == \Po (E \times F)] 
@@ -266,7 +266,7 @@ Definition inverse_graph r :=
 Lemma igraph_graph r: sgraph (inverse_graph r).
 Proof. move=> x /Zo_S xp; apply: (setX_pair xp). Qed.
 
-Hint Resolve igraph_graph: fprops.
+Global Hint Resolve igraph_graph: fprops.
 
 Lemma igraphP r y: 
   inc y (inverse_graph r) <-> (pairp y /\  inc (J (Q y)(P y)) r).
@@ -358,7 +358,7 @@ Lemma ifun_g f: graph (inverse_fun f) = inverse_graph (graph f).
 Proof. by rewrite /inverse_fun;aw. Qed.
 
 Hint Rewrite ifun_s ifun_t ifun_g : aw.
-Hint Resolve icor_correspondence: fprops.
+Global Hint Resolve icor_correspondence: fprops.
 
 (** Inverse image by a graph r of a set x *)
 
@@ -394,7 +394,7 @@ Notation "x \cg y" := (composeg x y) (at level 50).
 Lemma compg_graph r r': sgraph (r \cg r').
 Proof. by move=> t /Zo_P [/setX_pair]. Qed. 
 
-Hint Resolve compg_graph: fprops.
+Global Hint Resolve compg_graph: fprops.
 
 Lemma compg_P r r' x:
   inc x (r' \cg r) <->
@@ -642,7 +642,7 @@ Proof. by move=> [_ ]. Qed.
 Lemma f_range_graph f: function f -> sub (range (graph f))(target f).
 Proof. by move => [cf _ _]; apply:corresp_sub_range. Qed.
 
-Hint Resolve function_sgraph function_fgraph : fprops.
+Global Hint Resolve function_sgraph function_fgraph : fprops.
 
 Lemma ImfE f: function f -> Imf f =  range (graph f).
 Proof.
@@ -723,7 +723,7 @@ Proof. apply: fun_image_Starget1. Qed.
 
 End Vf_pr.
 
-Hint Resolve Vf_target : fprops.
+Global Hint Resolve Vf_target : fprops.
 
 Lemma Imf_i f x: function f -> inc x (source f) -> inc (Vf f x) (Imf f).
 Proof. move => ff xsf; apply/(Imf_P ff); ex_tac. Qed.
@@ -948,7 +948,7 @@ Proof. exact: (proj31 (identity_prop x)). Qed.
 Lemma idV x y: inc y x -> Vf (identity x) y = y.
 Proof. move =>yx; rewrite /Vf /identity; aw; apply:(identity_ev yx). Qed.
 
-Hint Resolve identity_f: fprops.
+Global Hint Resolve identity_f: fprops.
 Hint Rewrite idV : bw.
 
 Lemma identity_prop0 E f:
@@ -1799,7 +1799,7 @@ rewrite {1}/extension; aw => a b /setU1_P; case => av; move/setU1_P; case => bv.
 - by rewrite av bv.
 Qed.
 
-Hint Resolve extension_f: fprops.
+Global Hint Resolve extension_f: fprops.
 
 Lemma extension_f_injective x f g a b:
   function f -> function g -> target f = target g ->
@@ -1824,7 +1824,7 @@ Proof. by move => h; rewrite canonical_injectionE; apply:lf_injective. Qed.
 Lemma ci_f a b: sub a b -> function  (canonical_injection a b).
 Proof. move => h; exact (proj1 (ci_fi h)). Qed.
   
-Hint Resolve ci_f : fprops.
+Global Hint Resolve ci_f : fprops.
 
 Lemma ci_V a b x:
   sub a b -> inc x a -> Vf (canonical_injection a b) x = x.
@@ -2695,7 +2695,7 @@ Proof. by exists f.  Qed.
 Lemma EqR: reflexive_r equipotent.
 Proof. move => x; exists (identity x); apply: identity_bp. Qed.
 
-Hint Resolve EqR: fprops.
+Global Hint Resolve EqR: fprops.
 
 Lemma EqT: transitive_r equipotent.
 Proof. 
@@ -2892,7 +2892,7 @@ Qed.
 
 End Ext_to_prod.
 
-Hint Resolve  ext_to_prod_f: fprops.
+Global Hint Resolve  ext_to_prod_f: fprops.
 
 
 (** If the two functions are  injective, surjective, bijective, 

--- a/theories/sset2_aux.v
+++ b/theories/sset2_aux.v
@@ -105,7 +105,7 @@ set_extens t.
 move/funI_P => [x /IM_P [a ->] ->]; aw; trivial; apply: R_inc. 
 Qed.
 
-Hint Resolve acreate_function: fprops.
+Global Hint Resolve acreate_function: fprops.
 
 Lemma acreate_V  (A B:Set) (f:A->B) (x:A):
   Vf (acreate f)  (Ro x) =  Ro (f x).

--- a/theories/sset3.v
+++ b/theories/sset3.v
@@ -944,7 +944,7 @@ Definition variantLc f g:=  variantL C0 C1 f g.
 Lemma variantLc_fgraph x y:  fgraph (variantLc x y).
 Proof. rewrite/variantLc/variantL; fprops. Qed.
 
-Hint Resolve variant_fgraph variantLc_fgraph: fprops.
+Global Hint Resolve variant_fgraph variantLc_fgraph: fprops.
 
 Lemma variantLc_d f g: domain (variantLc f g) = C2.
 Proof. by rewrite/variantLc/variantL; aw. Qed.
@@ -1188,7 +1188,7 @@ move=> i j; rewrite  Lgd=> id jd ;rewrite ! LgV //.
 by mdi_tac t => u /indexed_P [_ _] qu /indexed_P [_ _]; rewrite qu.
 Qed.
 
-Hint Resolve disjointU_disjoint: fprops.
+Global Hint Resolve disjointU_disjoint: fprops.
 
 Lemma disjointU_fgraph f: fgraph (disjointU_fam f).
 Proof. rewrite /disjointU_fam; fprops. Qed.
@@ -1196,7 +1196,7 @@ Proof. rewrite /disjointU_fam; fprops. Qed.
 Lemma disjointU_d f: domain (disjointU_fam f) = domain f.
 Proof. by rewrite /disjointU_fam; aw. Qed.
 
-Hint Resolve  disjointU_fgraph: fprops.
+Global Hint Resolve  disjointU_fgraph: fprops.
 
 
 Lemma disjointU_E I (f:fterm ):
@@ -1365,7 +1365,7 @@ Lemma disjointU2_pr a b x y:
   x <> y ->  disjoint (a *s1 x) (b *s1 y).
 Proof. by move=> xy; apply: disjointU2_pr0; apply: disjointU2_pr1. Qed.
 
-Hint Resolve disjointU2_pr: fprops.
+Global Hint Resolve disjointU2_pr: fprops.
 
 
 Lemma Eq_du2 a b a' b' : disjoint a b ->  disjoint a' b' -> 
@@ -1476,7 +1476,7 @@ Proof.
 by move => cf /setP_P s; rewrite LfV //; apply: etp_axiom.
 Qed.
 
-Hint Resolve etp_f : fprops.
+Global Hint Resolve etp_f : fprops.
 
 (** Morphism properties of extension *)
 
@@ -2349,7 +2349,7 @@ Lemma pri_V f i x:
   Vf (pr_i f i) x = Vg x i. 
 Proof. by rewrite/pr_i=> id xp; rewrite LfV // ; apply: pri_axiom. Qed.
 
-Hint Resolve pri_f : fprops.
+Global Hint Resolve pri_f : fprops.
 
 (** Special case where the domain is empty *)
 

--- a/theories/sset4.v
+++ b/theories/sset4.v
@@ -127,7 +127,7 @@ Proof. by move => []. Qed.
 Lemma preorder_sgraph r: preorder r -> sgraph r.
 Proof. by move => []. Qed.
 
-Hint Resolve order_sgraph equivalence_sgraph : fprops.
+Global Hint Resolve order_sgraph equivalence_sgraph : fprops.
 
 Lemma reflexive_domain g: reflexivep g -> domain g = substrate g.
 Proof. 
@@ -706,7 +706,7 @@ Proof.
 move=> xy /setQ_P [pa pb]; apply: (@sub_class_substrate (rep y)); ue.
 Qed.
 
-Hint Resolve inc_class_setQ: fprops.
+Local Hint Resolve inc_class_setQ: fprops.
 
 Lemma setU_setQ: union (quotient r) = substrate r. 
 Proof.
@@ -758,7 +758,7 @@ Qed.
 
 End Class.
 
-Hint Resolve rep_i_sr inc_itself_class inc_class_setQ : fprops.
+Global Hint Resolve rep_i_sr inc_itself_class inc_class_setQ : fprops.
 
 
 (** Canonical projection on the quotient *)
@@ -779,7 +779,7 @@ Lemma canon_proj_t : target (canon_proj r) = quotient r.
 Proof. by rewrite /canon_proj; aw. Qed.
 
 Hint Rewrite canon_proj_s canon_proj_t: aw.
-Hint Resolve canon_proj_f: fprops.
+Local Hint Resolve canon_proj_f: fprops.
 
 Lemma canon_proj_V x:
   inc x (substrate r) -> Vf (canon_proj r) x = class r x.
@@ -843,7 +843,7 @@ Qed.
 End CanonProj.
 
 Hint Rewrite canon_proj_s canon_proj_t: aw.
-Hint Resolve canon_proj_f: fprops.
+Global Hint Resolve canon_proj_f: fprops.
 
 (** The diagonal is the graph of equality *)
 

--- a/theories/sset5.v
+++ b/theories/sset5.v
@@ -2759,7 +2759,7 @@ apply: the_greatest_pr => //; last by exists z.
 exact: (proj1 (iorder_osr or (Zo_S(p:=lower_bound r X)))).
 Qed.
 
-Hint Resolve supremum_pr1 infimum_pr1: fprops.
+Global Hint Resolve supremum_pr1 infimum_pr1: fprops.
 
 
 Lemma supremum_pr2 r X a: order  r -> 

--- a/theories/sset6.v
+++ b/theories/sset6.v
@@ -30,7 +30,7 @@ Definition worder_on G E := worder G /\ substrate G = E.
 Lemma worder_or r: worder r -> order r.
 Proof. exact: proj1. Qed.
 
-Hint Resolve worder_or: fprops.
+Global Hint Resolve worder_or: fprops.
 
 Lemma wordering_pr r x: 
   worder_r r -> {inc x, reflexive_r r} ->  
@@ -604,7 +604,7 @@ Proof. by move=> or xs;apply/segmentcP =>//; order_tac. Qed.
 Lemma sub_segmentc r x: sub (segmentc r x) (substrate r).
 Proof. by move=> t /Zo_S. Qed.
 
-Hint Resolve inc_bound_segmentc: fprops.
+Global Hint Resolve inc_bound_segmentc: fprops.
 
 Lemma segmentc_pr r x: order r -> inc x (substrate r) ->
   (segment r x) +s1 x = segmentc r x.
@@ -3223,7 +3223,7 @@ Proof. by split; [apply: orsum_or | rewrite orsum_sr]. Qed.
 
 End OrderSumBasic.
 
-Hint Resolve orsum_or orprod_or: fprops.
+Global Hint Resolve orsum_or orprod_or: fprops.
 
 Definition order_prod2 r r' :=
   order_prod canonical_doubleton_order (variantLc r' r).
@@ -3237,7 +3237,7 @@ Proof.
 by move => or or';hnf; aw;move=> i itp; try_lvariant itp.  
 Qed.
 
-Hint Resolve order_sp_axioms: fprops.
+Global Hint Resolve order_sp_axioms: fprops.
 
 Section OrderSum2Basic.
 Variables r r': Set.

--- a/theories/sset7.v
+++ b/theories/sset7.v
@@ -33,7 +33,7 @@ Definition osucc x := x +s1 x.
 Lemma succ_i x: inc x (osucc x).
 Proof. by apply:setU1_1.  Qed.
 
-Hint Resolve succ_i: fprops.
+Global Hint Resolve succ_i: fprops.
 
 Lemma transitive_setP x: transitive_set  x <-> sub (union x) x.
 Proof.
@@ -100,7 +100,7 @@ case /setU1_P: (ytx _ ty) => // tx; rewrite tx in ty.
 by case: yntxx; apply: (extensionality ytx); apply: setU1_sub => //; apply: tsy.
 Qed.
 
-Hint Resolve OS_succ : fprops.
+Global Hint Resolve OS_succ : fprops.
 
 Lemma ordinal_trans_dec x: ordinalp x -> trans_dec_set x. 
 Proof. 
@@ -382,7 +382,7 @@ Proof. exact: (proj1 (sub_osr x)). Qed.
 Lemma ordinal_o_tor x: ordinalp x -> total_order (ordinal_o x).
 Proof. by move=> or; apply: (worder_total (ordinal_o_wor or)). Qed.
 
-Hint Resolve ordinal_o_or ordinal_o_wor: fprops.
+Global Hint Resolve ordinal_o_or ordinal_o_wor: fprops.
 
 (** Two isomorphic ordinals are equal *)
 
@@ -943,7 +943,7 @@ Proof. exact: (proj1 wordering_ole). Qed.
 Lemma oleR x: ordinalp x -> x <=o x.
 Proof. by move=> or; split.  Qed.
 
-Hint Resolve oleR: fprops.
+Global Hint Resolve oleR: fprops.
 
 Lemma oleT y x z: x <=o y -> y <=o z -> x <=o z.
 Proof. move: ole_order_r => [p1 p2 _]; apply: p1. Qed.
@@ -1713,7 +1713,7 @@ Qed.
 Lemma OS_cardinal x: cardinalp x -> ordinalp x.
 Proof. by case.  Qed.
 
-Hint Resolve CS_cardinal: fprops.
+Global Hint Resolve CS_cardinal: fprops.
 
 Lemma double_cardinal x: cardinal x =c x.
 Proof. apply: card_card; fprops. Qed.
@@ -1843,7 +1843,7 @@ Proof. exact: (proj1 C2_ne_C01). Qed.
 Lemma card_12: \1c <> \2c.
 Proof. exact: (nesym (proj2 C2_ne_C01)). Qed.
 
-Hint Resolve card_12 card1_nz card2_nz: fprops.
+Global Hint Resolve card_12 card1_nz card2_nz: fprops.
 
 Lemma gfunctions_empty X: (gfunctions emptyset X) = \1c.
 Proof.
@@ -2030,7 +2030,7 @@ Proof. apply:CS_finite_o; apply:finite_one. Qed.
 Lemma CS2: cardinalp \2c.
 Proof. apply:CS_finite_o; apply:finite_two. Qed.
 
-Hint Resolve CS0 CS1 CS2 : fprops.
+Global Hint Resolve CS0 CS1 CS2 : fprops.
 
 (** We define finite and infinite for sets and cardinals *)
 
@@ -2047,7 +2047,7 @@ Qed.
 Lemma CS_finite x: finite_c x -> cardinalp x.
 Proof. by exact: CS_finite_o. Qed.
 
-Hint Resolve CS_finite: fprops.
+Global Hint Resolve CS_finite: fprops.
 
 
 Lemma finite_not_infinite x : finite_c x -> ~ infinite_c x.
@@ -2233,7 +2233,7 @@ Qed.
 Lemma OS_omega: ordinalp omega0.
 Proof. exact: (proj31 omega0_pr). Qed.
 
-Hint Resolve OS0 OS1 OS2 OS_omega : fprops.
+Global Hint Resolve OS0 OS1 OS2 OS_omega : fprops.
 
 Lemma OIS_omega: infinite_o omega0.
 Proof. exact: (proj32 omega0_pr). Qed.
@@ -2636,7 +2636,7 @@ Qed.
 Lemma cleR x: cardinalp x -> x <=c x.
 Proof. by move=> cx;split. Qed.
 
-Hint Resolve cleR: fprops.
+Global Hint Resolve cleR: fprops.
 
 Lemma cleT b a c: a <=c b -> b <=c c -> a <=c c.
 Proof.  
@@ -2943,7 +2943,7 @@ Proof. rewrite - osucc_zero;apply:iff_sym; exact:oleSltP. Qed.
 Lemma oge1 x: ordinalp x -> x <> \0o -> \1o <=o x.
 Proof. by move=> ox xne; apply/oge1P; apply: ord_ne0_pos. Qed.
 
-Hint Resolve oge1 : fprops.
+Global Hint Resolve oge1 : fprops.
 
 Lemma olt1 x:  x <o \1o -> x = \0o.
 Proof. by move/(oltP OS1) /set1_P. Qed.
@@ -3006,7 +3006,7 @@ Proof. rewrite - succ_zero; apply: succ_positive. Qed.
 Lemma cle_01: \0c <=c \1c.
 Proof. exact: (proj1 clt_01). Qed.
 
-Hint Resolve cle_01 clt_01 : fprops.
+Global Hint Resolve cle_01 clt_01 : fprops.
 
 Lemma cle_12: \1c <=c \2c.
 Proof. by split; fprops => // t /set1_P ->; apply:set2_1. Qed.

--- a/theories/sset8.v
+++ b/theories/sset8.v
@@ -53,7 +53,7 @@ Proof. rewrite /csum; fprops. Qed.
 Lemma CS_cprod f: cardinalp (cprod f).
 Proof. rewrite /cprod; fprops. Qed.
 
-Hint Resolve  CS_csum CS_cprod: fprops.
+Global Hint Resolve  CS_csum CS_cprod: fprops.
 
 Theorem cprod_pr f: cprod f = cprodb (domain f) (fun a => cardinal (Vg f a)).
 Proof. by rewrite - cprod_gr; apply cprod_pr0. Qed.
@@ -342,7 +342,7 @@ Proof. rewrite/csum2/csumb; fprops. Qed.
 Lemma CS_prod2 a b: cardinalp (a *c b).
 Proof. rewrite /cprod2/cprodb; fprops. Qed.
 
-Hint Resolve CS_sum2 CS_prod2: fprops.
+Global Hint Resolve CS_sum2 CS_prod2: fprops.
 
 Lemma csum2_pr a b f: doubleton_fam f a b -> a +c b = csum f.
 Proof.
@@ -826,7 +826,7 @@ Notation "x ^c y" := (cpow x y) (at level 30).
 Lemma CS_pow a b: cardinalp (a ^c b).
 Proof. apply:CS_cardinal. Qed.
 
-Hint Resolve CS_pow: fprops.
+Global Hint Resolve CS_pow: fprops.
 
 Lemma cpow_pr0 a b: a ^c b = cardinal (gfunctions b a).
 Proof. by apply/card_eqP; apply:Eq_fun_set. Qed.
@@ -1376,7 +1376,7 @@ Proof. by move /NatP. Qed.
 Lemma Nat_hi a: natp a -> finite_c a.
 Proof. by move /NatP. Qed.
 
-Hint Resolve Nat_i Nat_hi: fprops.
+Global Hint Resolve Nat_i Nat_hi: fprops.
 
 Lemma CS_nat x: natp x -> cardinalp x.
 Proof. fprops. Qed.
@@ -1398,8 +1398,8 @@ Proof. by move => /NatP h;rewrite (succ_of_finite h); apply/NatP/finite_sP. Qed.
 Lemma NS_nsucc x: cardinalp x -> natp (csucc x) -> natp x.
 Proof. by  move => xs /NatP/(finite_succP xs) /NatP. Qed.
 
-Hint Resolve CS_nat : fprops.
-Hint Resolve NS_succ: fprops.
+Global Hint Resolve CS_nat : fprops.
+Global Hint Resolve NS_succ: fprops.
 
 Lemma Nsucc_rw x: natp x -> csucc x = x +c \1c.
 Proof. by move=> fx; apply: csucc_pr4; fprops. Qed.
@@ -1508,7 +1508,7 @@ Proof. move: NS2; rewrite /card_three; fprops. Qed.
 Lemma NS4: natp \4c.
 Proof. move: NS3; rewrite /card_four; fprops. Qed.
 
-Hint Resolve NS0 NS1 NS2: fprops.
+Global Hint Resolve NS0 NS1 NS2: fprops.
 
 
 Lemma finite_0: finite_c \0c.
@@ -1520,7 +1520,7 @@ Proof. fprops. Qed.
 Lemma finite_2: finite_c \2c.
 Proof. fprops. Qed.
 
-Hint Resolve finite_0 finite_1 finite_2 : fprops.
+Global Hint Resolve finite_0 finite_1 finite_2 : fprops.
 
 Lemma csum_22: \2c +c \2c = \4c.
 Proof.
@@ -1598,7 +1598,7 @@ Proof.
 move => h; apply:(NS_le_nat (cdiff_le1 b (CS_nat h)) h).
 Qed.
 
-Hint Resolve  NS_diff: fprops.
+Global Hint Resolve  NS_diff: fprops.
 
 Definition cpred := opred. 
 
@@ -1667,7 +1667,7 @@ Proof. by move=> /CS_nat /cleS0. Qed.
 Lemma cltS a: natp a -> a <c (csucc a).
 Proof. by move => aN; apply/(NltP (NS_succ aN)); apply: Nsucc_i. Qed.
 
-Hint Resolve cleS cltS: fprops.
+Global Hint Resolve cleS cltS: fprops.
 
 Lemma cle_24: \2c <=c \4c.
 Proof. exact: (cleT (cleS NS2)(cleS NS3)). Qed.
@@ -2120,8 +2120,8 @@ Qed.
 Lemma NS_pow2 n: natp n -> natp (\2c ^c n).
 Proof. apply: NS_pow; fprops. Qed.
 
-Hint Resolve NS_sum NS_prod: fprops.
-Hint Resolve NS_pow NS_pow2: fprops.
+Global Hint Resolve NS_sum NS_prod: fprops.
+Global Hint Resolve NS_pow NS_pow2: fprops.
 
 
 Lemma setU2_finite x y:

--- a/theories/sset9.v
+++ b/theories/sset9.v
@@ -1470,7 +1470,7 @@ Proof.
 move => aN ; rewrite cremE; apply: (NS_diff _ aN).
 Qed.
 
-Hint Resolve  NS_rem NS_quo: fprops.
+Global Hint Resolve  NS_rem NS_quo: fprops.
 
 Lemma cdiv_pr a b: natp a -> natp b -> 
   a = (b *c (a %/c b)) +c (a %%c b).
@@ -3825,7 +3825,7 @@ move: n nN; apply: Nat_induction.
 move => n nN [sa sb]; split => //; rewrite (Fib_rec nN); fprops.
 Qed.
 
-Hint Resolve NS_Fib : fprops.
+Global Hint Resolve NS_Fib : fprops.
 
 Lemma Fib_gt0 n: natp n -> n <> \0c ->  (Fib n) <> \0c.
 Proof.
@@ -4900,7 +4900,7 @@ move: n;apply: Nat_induction; first by rewrite factorial0; fprops.
 move=> m mN u; rewrite (factorial_succ mN); fprops.
 Qed.
 
-Hint Resolve  factorial_nz: fprops.
+Global Hint Resolve  factorial_nz: fprops.
 
 Lemma factorial_prop f: f \0c = \1c ->
   (forall n, natp n -> f (csucc n) =  (f n) *c (csucc n)) ->

--- a/theories/ssete9.v
+++ b/theories/ssete9.v
@@ -452,7 +452,7 @@ Notation "x > y"  := (y < x) (only parsing)  : cantor_scope.
 Lemma T1lenn x: x <= x.   
 Proof. by rewrite /T1le eqxx. Qed.
 
-Hint Resolve T1lenn : core.
+Global Hint Resolve T1lenn : core.
 
 Lemma T1ltnn x: (x < x) = false.
 Proof. by elim:x => //= a -> n b ->; rewrite ltnn ! if_same. Qed.
@@ -3054,7 +3054,7 @@ Qed.
 Lemma T2lenn x: x <= x.   
 Proof. by rewrite /T2le eqxx. Qed.
 
-Hint Resolve T2lenn : core.
+Global Hint Resolve T2lenn : core.
 
 
 Lemma T2ge1 x:  (one <= x) = (x != zero).
@@ -4877,7 +4877,7 @@ Qed.
 Lemma T3lenn x: x <= x.   
 Proof. by rewrite /T3le eqxx. Qed.
 
-Hint Resolve T3lenn : core.
+Global Hint Resolve T3lenn : core.
 
 Lemma T3leNgt a b:  (a <= b) = ~~ (b < a).
 Proof.


### PR DESCRIPTION
Mark project as compatible with Coq 8.13 and MC 1.12.0, but we don't test this yet due to missing Docker containers.