### PR TITLE
Prepare for release compatible with Coq 8.13 and 8.14, MathComp 1.12

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,4 +1,6 @@
-name: CI
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+name: Docker CI
 
 on:
   push:
@@ -16,6 +18,7 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.12.0-coq-8.11'
           - 'mathcomp/mathcomp:1.12.0-coq-8.10'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
+<!---
+This file was generated from `meta.yml`, please do not edit manually.
+Follow the instructions on https://github.com/coq-community/templates to regenerate.
+--->
 # Gaia
 
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 
-[action-shield]: https://github.com/coq-community/gaia/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/coq-community/gaia/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/coq-community/gaia/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/gaia/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
@@ -34,7 +38,7 @@ and number theory.
 - License: [MIT License](LICENSE)
 - Compatible Coq versions: 8.10 or later
 - Additional dependencies:
-  - [MathComp ssreflect 1.11 or later](https://math-comp.github.io)
+  - [MathComp ssreflect 1.12 or later](https://math-comp.github.io)
   - [MathComp algebra](https://math-comp.github.io)
 - Coq namespace: `gaia`
 - Related publication(s):

--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,7 @@
 -arg -w -arg -ambiguous-paths
 -arg -w -arg -deprecated-hint-without-locality
 -arg -w -arg -deprecated-ident-entry
+-arg -w -arg -deprecated-hint-rewrite-without-locality
 theories/fibm.v
 theories/sset1.v
 theories/sset10.v

--- a/coq-gaia.opam
+++ b/coq-gaia.opam
@@ -1,3 +1,6 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
 opam-version: "2.0"
 maintainer: "palmskog@gmail.com"
 version: "dev"
@@ -16,7 +19,7 @@ and number theory."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.13~") | (= "dev")}
   "coq-mathcomp-algebra" 
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -50,7 +50,7 @@ license:
 
 supported_coq_versions:
   text: '8.10 or later'
-  opam: '{(>= "8.10" & < "8.13~") | (= "dev")}'
+  opam: '{(>= "8.10" & < "8.15~") | (= "dev")}'
 
 dependencies:
 - opam:
@@ -66,6 +66,8 @@ dependencies:
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
+- version: '1.12.0-coq-8.13'
+  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.11'

--- a/theories/dune
+++ b/theories/dune
@@ -2,4 +2,10 @@
  (name gaia)
  (package coq-gaia)
  (synopsis "Implementation of books from Bourbaki's Elements of Mathematics in Coq")
- (flags -w -notation-overridden -w -notation-incompatible-format -w -ambiguous-paths -w -deprecated-hint-without-locality -w -deprecated-ident-entry))
+ (flags
+   -w -notation-overridden
+   -w -notation-incompatible-format
+   -w -ambiguous-paths
+   -w -deprecated-hint-without-locality
+   -w -deprecated-ident-entry
+   -w -deprecated-hint-rewrite-without-locality))

--- a/theories/fibm.v
+++ b/theories/fibm.v
@@ -5543,7 +5543,7 @@ have ph: Zeck (Zeckp (Zeckp m)) = s2.
 have qg: llen k.*2 (Zeck_li (Zeckpn 2 m)). 
   move: qe mz; rewrite /s1 /Zeck_li ph qi /pred_seq -map_comp /comp /=. 
   by case s2 => // a l h _ /=; move/(allP h) :(map_f succn (mem_last a l)). 
-by rewrite -qh (Hrec _ qg qf)  /Zeckpn - ! iter_add // !addn2 doubleS.
+by rewrite -qh (Hrec _ qg qf)  /Zeckpn - ! iterD // !addn2 doubleS.
 Qed.
 
 

--- a/theories/ssete7.v
+++ b/theories/ssete7.v
@@ -3541,11 +3541,11 @@ Proof.
 move => ba.
 move: (subnK ba); rewrite addnC => <-; rewrite - addnA leq_add2l => le1.
 move: (leq_trans (leq_addr n (a-b)) le1) => aux.
-move: (iota_add b (a-b)(m -(a-b))); rewrite addnC (subnK aux) => ->.
+move: (iotaD b (a-b)(m -(a-b))); rewrite addnC (subnK aux) => ->.
 rewrite -{1}(cat0s (iota (b + (a - b)) n)); apply: cat_subseq => //.
   apply: sub0seq.
 have nm: n <= (m - (a - b)) by rewrite -(leq_add2l (a-b)) subnKC //.
-set c := (b + (a - b)); move: (iota_add  c n ((m - (a - b)) - n)).
+set c := (b + (a - b)); move: (iotaD  c n ((m - (a - b)) - n)).
 rewrite addnC (subnK nm) => ->.
 rewrite -{1}(cats0 (iota c n)); apply: cat_subseq => //; apply: sub0seq.
 Qed.


### PR DESCRIPTION
This PR prepares for a release based on MathComp 1.12, compatible with Coq 8.10 to 8.14. We ignore deprecations not fixable for this range of versions and explicitly fix two MathComp deprecations. Coq 8.10 to 8.13 is tested in CI. I had to test 8.14 locally.