### PR TITLE
allow MathComp 1.14.0 in opam and test in CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -21,6 +21,8 @@ jobs:
           - 'mathcomp/mathcomp-dev:coq-8.13'
           - 'mathcomp/mathcomp-dev:coq-8.12'
           - 'mathcomp/mathcomp-dev:coq-8.11'
+          - 'mathcomp/mathcomp:1.14.0-coq-8.15'
+          - 'mathcomp/mathcomp:1.14.0-coq-8.14'
           - 'mathcomp/mathcomp:1.13.0-coq-8.14'
           - 'mathcomp/mathcomp:1.13.0-coq-8.13'
           - 'mathcomp/mathcomp:1.13.0-coq-8.12'

--- a/coq-gaia-numbers.opam
+++ b/coq-gaia-numbers.opam
@@ -16,7 +16,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.15~") | (= "dev")}
   "coq-mathcomp-algebra"
   "coq-gaia-theory-of-sets" {= version}
   "coq-gaia-ordinals" {= version}

--- a/coq-gaia-ordinals.opam
+++ b/coq-gaia-ordinals.opam
@@ -16,7 +16,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.15~") | (= "dev")}
   "coq-gaia-theory-of-sets" {= version}
   "coq-gaia-schutte" {= version}
 ]

--- a/coq-gaia-schutte.opam
+++ b/coq-gaia-schutte.opam
@@ -16,7 +16,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.15~") | (= "dev")}
 ]
 
 tags: [

--- a/coq-gaia-stern.opam
+++ b/coq-gaia-stern.opam
@@ -16,7 +16,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.15~") | (= "dev")}
   "coq-mathcomp-algebra"
 ]
 

--- a/coq-gaia-theory-of-sets.opam
+++ b/coq-gaia-theory-of-sets.opam
@@ -16,7 +16,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.15~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -67,7 +67,7 @@ supported_coq_versions:
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.12.0" & < "1.14~") | (= "dev")}'
+    version: '{(>= "1.12.0" & < "1.15~") | (= "dev")}'
   description: |-
     [MathComp ssreflect 1.12 or later](https://math-comp.github.io)
 - opam:
@@ -88,6 +88,10 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.11'
   repo: 'mathcomp/mathcomp-dev'
+- version: '1.14.0-coq-8.15'
+  repo: 'mathcomp/mathcomp'
+- version: '1.14.0-coq-8.14'
+  repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.13'


### PR DESCRIPTION
@thery OK with you if I merge this when CI passes and do a GitHub release? This should allow easier reuse of Gaia in Hydras & Co.